### PR TITLE
refactor: invert color scheme to light mode default with dark mode preference

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -40,7 +40,6 @@ function SingleSelectButtonGroup<T extends string>({
               ? "bg-[var(--color-primary)] text-[var(--selected-text-color)]"
               : "bg-[var(--color-surface-light)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]"
           }`}
-          style={selected === option ? { color: '#171717', WebkitTextFillColor: '#171717' } : {}}
         >
           {option.charAt(0).toUpperCase() + option.slice(1)}
         </button>
@@ -79,7 +78,6 @@ function MultiSelectButtonGroup<T extends string>({
               ? "bg-[var(--color-primary)] text-[var(--selected-text-color)]"
               : "bg-[var(--color-surface-light)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]"
           }`}
-          style={selected.includes(option) ? { color: '#171717', WebkitTextFillColor: '#171717' } : {}}
         >
           {option}
         </button>
@@ -402,7 +400,6 @@ export default function PassphraseGenerator() {
                       ? "bg-[var(--color-primary)] text-[var(--selected-text-color)]"
                       : "bg-[var(--color-surface-light)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]"
                   }`}
-                  style={capitalize ? { color: '#171717', WebkitTextFillColor: '#171717' } : {}}
                 >
                   Capitalize
                 </button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -40,6 +40,7 @@ function SingleSelectButtonGroup<T extends string>({
               ? "bg-[var(--color-primary)] text-[var(--selected-text-color)]"
               : "bg-[var(--color-surface-light)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]"
           }`}
+          style={selected === option ? { color: '#171717', WebkitTextFillColor: '#171717' } : {}}
         >
           {option.charAt(0).toUpperCase() + option.slice(1)}
         </button>
@@ -78,6 +79,7 @@ function MultiSelectButtonGroup<T extends string>({
               ? "bg-[var(--color-primary)] text-[var(--selected-text-color)]"
               : "bg-[var(--color-surface-light)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]"
           }`}
+          style={selected.includes(option) ? { color: '#171717', WebkitTextFillColor: '#171717' } : {}}
         >
           {option}
         </button>
@@ -400,6 +402,7 @@ export default function PassphraseGenerator() {
                       ? "bg-[var(--color-primary)] text-[var(--selected-text-color)]"
                       : "bg-[var(--color-surface-light)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]"
                   }`}
+                  style={capitalize ? { color: '#171717', WebkitTextFillColor: '#171717' } : {}}
                 >
                   Capitalize
                 </button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -310,11 +310,30 @@ export default function PassphraseGenerator() {
     }
   }, [generatorType]);
 
+  // Detect and apply color scheme
+  useEffect(() => {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.body.classList.toggle('dark-mode', prefersDark);
+    document.body.classList.toggle('light-mode', !prefersDark);
+    
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (e: MediaQueryListEvent) => {
+      document.body.classList.toggle('dark-mode', e.matches);
+      document.body.classList.toggle('light-mode', !e.matches);
+    };
+    
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
   return (
     <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-text-primary)] flex flex-col items-center justify-center p-4">
       <Head>
         <title>PwZap</title>
         <meta name="description" content="Secure passwords, made simple." />
+        <meta name="color-scheme" content="dark light" />
+        <meta name="theme-color" content="#121212" media="(prefers-color-scheme: dark)" />
+        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
       </Head>
 
       <div className="w-full max-w-2xl bg-[var(--color-surface)] rounded-xl shadow-xl p-6 md:p-8">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -59,3 +59,27 @@ button.yellow,
   color: var(--selected-text-color);
   background-color: var(--color-primary);
 }
+
+/* Prevent Chrome's force-dark mode from changing text colors */
+@media (forced-colors: active), (-ms-high-contrast: active) {
+  .tab-button.active,
+  .nav-button.active,
+  button.primary,
+  button.yellow,
+  .option.active,
+  .tab.selected,
+  .tab[aria-selected="true"],
+  .option-button.selected,
+  [class*="bg-[var(--color-primary)]"] {
+    color: #171717 !important;
+    -webkit-text-fill-color: #171717 !important;
+    forced-color-adjust: none;
+  }
+}
+
+/* Additional protection against Chrome's force-dark mode */
+button[class*="bg-[var(--color-primary)]"] {
+  color: #171717 !important;
+  -webkit-text-fill-color: #171717 !important;
+  forced-color-adjust: none;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,31 +6,42 @@
 }
 
 :root {
-  --background: #ffffff;
+  /* Light mode colors (default) */
+  --background: #f8f9fa;
   --foreground: #171717;
   --color-primary: #ffc107;
-  --color-primary-text: #ffeb3b;
-  --color-primary-light: #fff59d;
+  --color-primary-text: #ff9800;
+  --color-primary-light: #ffecb3;
   --color-primary-border: #ffd54f;
-  --color-background: #0e0d0d;
-  --color-surface: #121212;
-  --color-surface-hover: #333333;
-  --color-surface-light: #1e1e1e;
-  --color-text-primary: #ffffff;
-  --color-text-secondary: #f5f5f5;
-  --color-text-muted: #bdbdbd;
-  --color-text-dim: #757575;
-  --color-success: #ffd700;
-  --color-error: #ff5252;
-  --heading-color: #ffc107;
-  --box-border-color: #333333;
+  --color-background: #ffffff;
+  --color-surface: #f5f5f5;
+  --color-surface-hover: #e0e0e0;
+  --color-surface-light: #eeeeee;
+  --color-text-primary: #212121;
+  --color-text-secondary: #424242;
+  --color-text-muted: #757575;
+  --color-text-dim: #9e9e9e;
+  --color-success: #4caf50;
+  --color-error: #f44336;
+  --heading-color: #ff9800;
+  --box-border-color: #e0e0e0;
   --selected-text-color: #171717;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
+    /* Dark mode colors (preferred) */
     --background: #000000;
     --foreground: #ffffff;
+    --color-background: #0e0d0d;
+    --color-surface: #121212;
+    --color-surface-hover: #333333;
+    --color-surface-light: #1e1e1e;
+    --color-text-primary: #ffffff;
+    --color-text-secondary: #f5f5f5;
+    --color-text-muted: #bdbdbd;
+    --color-text-dim: #757575;
+    --box-border-color: #333333;
   }
 }
 
@@ -58,4 +69,45 @@ button.yellow,
 .option-button.selected {
   color: var(--selected-text-color);
   background-color: var(--color-primary);
+}
+
+/* Ensure selected buttons always have dark text regardless of color mode */
+button[class*="bg-[var(--color-primary)]"] {
+  color: var(--selected-text-color) !important;
+}
+
+/* Force color mode classes */
+body.light-mode {
+  --background: #f8f9fa;
+  --foreground: #171717;
+  --color-background: #ffffff;
+  --color-surface: #f5f5f5;
+  --color-surface-hover: #e0e0e0;
+  --color-surface-light: #eeeeee;
+  --color-text-primary: #212121;
+  --color-text-secondary: #424242;
+  --color-text-muted: #757575;
+  --color-text-dim: #9e9e9e;
+  --box-border-color: #e0e0e0;
+}
+
+body.dark-mode {
+  --background: #000000;
+  --foreground: #ffffff;
+  --color-background: #0e0d0d;
+  --color-surface: #121212;
+  --color-surface-hover: #333333;
+  --color-surface-light: #1e1e1e;
+  --color-text-primary: #ffffff;
+  --color-text-secondary: #f5f5f5;
+  --color-text-muted: #bdbdbd;
+  --color-text-dim: #757575;
+  --box-border-color: #333333;
+}
+
+/* Handle Chrome's force-dark mode */
+@media (forced-colors: active) {
+  button[class*="bg-[var(--color-primary)]"] {
+    forced-color-adjust: none;
+  }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -59,27 +59,3 @@ button.yellow,
   color: var(--selected-text-color);
   background-color: var(--color-primary);
 }
-
-/* Prevent Chrome's force-dark mode from changing text colors */
-@media (forced-colors: active), (-ms-high-contrast: active) {
-  .tab-button.active,
-  .nav-button.active,
-  button.primary,
-  button.yellow,
-  .option.active,
-  .tab.selected,
-  .tab[aria-selected="true"],
-  .option-button.selected,
-  [class*="bg-[var(--color-primary)]"] {
-    color: #171717 !important;
-    -webkit-text-fill-color: #171717 !important;
-    forced-color-adjust: none;
-  }
-}
-
-/* Additional protection against Chrome's force-dark mode */
-button[class*="bg-[var(--color-primary)]"] {
-  color: #171717 !important;
-  -webkit-text-fill-color: #171717 !important;
-  forced-color-adjust: none;
-}


### PR DESCRIPTION
refactor: invert color scheme to light mode default with dark mode preference

- Set light mode as default, dark mode as preferred option.
- Added meta tags for dark mode preference.
- Introduced CSS classes to force color modes.
- Added media query for mode detection.
- Protected against Chrome's force-dark mode.
- Ensured consistent button text colors across modes.
